### PR TITLE
Add City Planner snapshots

### DIFF
--- a/src/Application.Client.Web/CityPlanner/Abstractions/ICityPlanner.cs
+++ b/src/Application.Client.Web/CityPlanner/Abstractions/ICityPlanner.cs
@@ -1,7 +1,6 @@
 using System.Drawing;
-using Ingweland.Fog.Application.Client.Web.ViewModels.Hoh.City;
+using Ingweland.Fog.Application.Client.Web.CityPlanner.Snapshots;
 using Ingweland.Fog.Dtos.Hoh.City;
-using Ingweland.Fog.Dtos.Hoh.CityPlanner;
 using Ingweland.Fog.Models.Fog.Entities;
 using Ingweland.Fog.Models.Hoh.Enums;
 using SkiaSharp;
@@ -12,22 +11,26 @@ public interface ICityPlanner
 {
     public event Action? StateHasChanged;
     Rectangle Bounds { get; }
-    HohCity GetCity();
-    Task InitializeAsync();
-    HohCity CreateNew(string cityName);
-    void RenderScene(SKCanvas canvas);
-    CityMapEntity AddEntity(BuildingGroup buildingGroup);
-    bool TrySelectCityMapEntity(Point coordinates, out CityMapEntity? cityMapEntity);
-    void UpdateEntityState(CityMapEntity entity);
-    Task InitializeAsync(HohCity city);
-    void SelectGroup();
-    void RotateEntity(CityMapEntity entity);
-    void DeleteEntity(CityMapEntity entity);
-    void AddEntity(CityMapEntity entity);
-    void MoveEntity(CityMapEntity entity, Point location);
-    bool CanBePlaced(CityMapEntity cityMapEntity);
-    CityMapEntity UpdateLevel(CityMapEntity entity, int level);
-    void UpdateCustomization(BuildingCustomizationDto customization);
     CityMapState CityMapState { get; }
+    CityMapEntity AddEntity(BuildingGroup buildingGroup);
+    void AddEntity(CityMapEntity entity);
+    bool CanBePlaced(CityMapEntity cityMapEntity);
+    SnapshotsComparisonViewModel CompareSnapshots();
+    HohCity CreateNew(string cityName);
+    Task CreateSnapshot();
+    void DeleteEntity(CityMapEntity entity);
+    Task DeleteSnapshot(string id);
+    Task InitializeAsync();
+    Task InitializeAsync(HohCity city);
+    Task LoadSnapshot(string id);
+    void MoveEntity(CityMapEntity entity, Point location);
+    void RenderScene(SKCanvas canvas);
+    void RotateEntity(CityMapEntity entity);
+    Task SaveCity();
+    void SelectGroup();
+    bool TrySelectCityMapEntity(Point coordinates, out CityMapEntity? cityMapEntity);
+    void UpdateCustomization(BuildingCustomizationDto customization);
+    void UpdateEntityState(CityMapEntity entity);
+    CityMapEntity UpdateLevel(CityMapEntity entity, int level);
     void UpdateProduct(string productId);
 }

--- a/src/Application.Client.Web/CityPlanner/Abstractions/IHohCityFactory.cs
+++ b/src/Application.Client.Web/CityPlanner/Abstractions/IHohCityFactory.cs
@@ -7,5 +7,7 @@ public interface IHohCityFactory
 {
     HohCity CreateNewCapital();
     HohCity CreateNewCapital(string cityName);
-    HohCity Create(string id, CityId inGameCityId, string ageId, string name, IReadOnlyCollection<CityMapEntity> entities);
+
+    HohCity Create(string id, CityId inGameCityId, string ageId, string name,
+        IReadOnlyCollection<CityMapEntity> entities, IReadOnlyCollection<HohCitySnapshot> snapshots);
 }

--- a/src/Application.Client.Web/CityPlanner/CityMapStateFactory.cs
+++ b/src/Application.Client.Web/CityPlanner/CityMapStateFactory.cs
@@ -4,6 +4,7 @@ using Ingweland.Fog.Application.Client.Web.Factories;
 using Ingweland.Fog.Application.Client.Web.Factories.Interfaces;
 using Ingweland.Fog.Application.Client.Web.ViewModels.Hoh;
 using Ingweland.Fog.Application.Client.Web.ViewModels.Hoh.City;
+using Ingweland.Fog.Application.Core.Factories.Interfaces;
 using Ingweland.Fog.Dtos.Hoh;
 using Ingweland.Fog.Dtos.Hoh.City;
 using Ingweland.Fog.Models.Fog.Entities;
@@ -13,7 +14,6 @@ namespace Ingweland.Fog.Application.Client.Web.CityPlanner;
 
 public class CityMapStateFactory(
     ICityMapEntityFactory cityMapEntityFactory,
-    ILogger<CityMapState> cityMapStateLogger,
     IBuildingLevelRangesFactory buildingLevelRangesFactory)
     : ICityMapStateFactory
 {
@@ -25,7 +25,7 @@ public class CityMapStateFactory(
     {
         var buildingDictionary = buildings.ToDictionary(b => b.Id);
         var age = ages.First(a => a.Id == city.AgeId);
-        var state = new CityMapState(buildingLevelRangesFactory, cityMapStateLogger)
+        var state = new CityMapState(buildingLevelRangesFactory)
         {
             Buildings = buildingDictionary,
             BuildingCustomizations = buildingCustomizations,
@@ -34,6 +34,7 @@ public class CityMapStateFactory(
             InGameCityId = city.InGameCityId,
             CityName = city.Name,
             CityAge = age,
+            Snapshots = city.Snapshots,
         };
         state.AddRange(city.Entities.Select(hohCityMapEntity =>
         {

--- a/src/Application.Client.Web/CityPlanner/HohCityFactory.cs
+++ b/src/Application.Client.Web/CityPlanner/HohCityFactory.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using Ingweland.Fog.Application.Client.Web.CityPlanner.Abstractions;
+using Ingweland.Fog.Application.Core.Factories.Interfaces;
 using Ingweland.Fog.Models.Fog.Entities;
 using Ingweland.Fog.Models.Hoh.Constants;
 using Ingweland.Fog.Models.Hoh.Enums;
@@ -36,15 +37,16 @@ public class HohCityFactory(IMapper mapper) : IHohCityFactory
     }
 
     public HohCity Create(string id, CityId inGameCityId, string ageId, string name,
-        IReadOnlyCollection<CityMapEntity> entities)
+        IReadOnlyCollection<CityMapEntity> entities, IReadOnlyCollection<HohCitySnapshot> snapshots)
     {
         return new HohCity()
         {
             Id = id,
             InGameCityId = inGameCityId,
             AgeId = ageId,
-            Entities = mapper.Map<IList<HohCityMapEntity>>(entities),
+            Entities = mapper.Map<IReadOnlyCollection<HohCityMapEntity>>(entities),
             Name = name,
+            Snapshots = snapshots,
         };
     }
 }

--- a/src/Application.Client.Web/CityPlanner/Snapshots/Abstractions/ISnapshotsComparisonViewModelFactory.cs
+++ b/src/Application.Client.Web/CityPlanner/Snapshots/Abstractions/ISnapshotsComparisonViewModelFactory.cs
@@ -1,0 +1,9 @@
+using Ingweland.Fog.Application.Client.Web.CityPlanner.Stats;
+using Ingweland.Fog.Models.Fog.Entities;
+
+namespace Ingweland.Fog.Application.Client.Web.CityPlanner.Snapshots.Abstractions;
+
+public interface ISnapshotsComparisonViewModelFactory
+{
+    SnapshotsComparisonViewModel Create(IReadOnlyDictionary<HohCitySnapshot, CityStats> stats);
+}

--- a/src/Application.Client.Web/CityPlanner/Snapshots/SnapshotsComparisonCellValue.cs
+++ b/src/Application.Client.Web/CityPlanner/Snapshots/SnapshotsComparisonCellValue.cs
@@ -1,0 +1,8 @@
+namespace Ingweland.Fog.Application.Client.Web.CityPlanner.Snapshots;
+
+public class SnapshotsComparisonCellValue
+{
+    public bool IsLargest { get; init; }
+
+    public required string Value { get; init; }
+}

--- a/src/Application.Client.Web/CityPlanner/Snapshots/SnapshotsComparisonRow.cs
+++ b/src/Application.Client.Web/CityPlanner/Snapshots/SnapshotsComparisonRow.cs
@@ -1,0 +1,7 @@
+namespace Ingweland.Fog.Application.Client.Web.CityPlanner.Snapshots;
+
+public class SnapshotsComparisonRow
+{
+    public required string Header { get; init; }
+    public required IReadOnlyCollection<SnapshotsComparisonCellValue> Cells { get; init; }
+}

--- a/src/Application.Client.Web/CityPlanner/Snapshots/SnapshotsComparisonViewModel.cs
+++ b/src/Application.Client.Web/CityPlanner/Snapshots/SnapshotsComparisonViewModel.cs
@@ -1,0 +1,7 @@
+namespace Ingweland.Fog.Application.Client.Web.CityPlanner.Snapshots;
+
+public class SnapshotsComparisonViewModel
+{
+    public required IReadOnlyCollection<string> SnapshotNames { get; init; }
+    public required IReadOnlyCollection<SnapshotsComparisonRow> Production { get; init; }
+}

--- a/src/Application.Client.Web/CityPlanner/Snapshots/SnapshotsComparisonViewModelFactory.cs
+++ b/src/Application.Client.Web/CityPlanner/Snapshots/SnapshotsComparisonViewModelFactory.cs
@@ -1,0 +1,51 @@
+using Ingweland.Fog.Application.Client.Web.CityPlanner.Snapshots.Abstractions;
+using Ingweland.Fog.Application.Client.Web.CityPlanner.Stats;
+using Ingweland.Fog.Application.Client.Web.Providers.Interfaces;
+using Ingweland.Fog.Models.Fog.Entities;
+
+namespace Ingweland.Fog.Application.Client.Web.CityPlanner.Snapshots;
+
+public class SnapshotsComparisonViewModelFactory(IHohResourceIconUrlProvider resourceIconUrlProvider)
+    : ISnapshotsComparisonViewModelFactory
+{
+    public SnapshotsComparisonViewModel Create(IReadOnlyDictionary<HohCitySnapshot, CityStats> stats)
+    {
+        var columns = stats.Keys.ToList();
+        return new SnapshotsComparisonViewModel()
+        {
+            SnapshotNames = columns.Select(src => src.ComputedName).ToList(),
+            Production = CreateProductionItems(columns, stats),
+        };
+    }
+
+    private List<SnapshotsComparisonRow> CreateProductionItems(List<HohCitySnapshot> columns,
+        IReadOnlyDictionary<HohCitySnapshot, CityStats> stats)
+    {
+        var rows = new List<SnapshotsComparisonRow>();
+        var allProducts = stats.Values.SelectMany(src => src.Products.Keys).ToHashSet();
+        foreach (var productKey in allProducts)
+        {
+            var values = columns.Select(column =>
+                stats[column].Products.TryGetValue(productKey, out var value)
+                    ? value.Default
+                    : 0).ToList();
+            var maxValue = values.Max();
+            var different = values.Any(i => i != maxValue);
+
+            var cells = values.Select(i => new SnapshotsComparisonCellValue()
+            {
+                Value = i != 0 ? i.ToString("N0") : "-",
+                IsLargest = different && i == maxValue,
+            }).ToList();
+
+            var row = new SnapshotsComparisonRow()
+            {
+                Header = resourceIconUrlProvider.GetIconUrl(productKey),
+                Cells = cells,
+            };
+            rows.Add(row);
+        }
+
+        return rows;
+    }
+}

--- a/src/Application.Client.Web/DependencyInjection.cs
+++ b/src/Application.Client.Web/DependencyInjection.cs
@@ -4,6 +4,8 @@ using Ingweland.Fog.Application.Client.Web.CityPlanner;
 using Ingweland.Fog.Application.Client.Web.CityPlanner.Abstractions;
 using Ingweland.Fog.Application.Client.Web.CityPlanner.Commands;
 using Ingweland.Fog.Application.Client.Web.CityPlanner.Rendering;
+using Ingweland.Fog.Application.Client.Web.CityPlanner.Snapshots;
+using Ingweland.Fog.Application.Client.Web.CityPlanner.Snapshots.Abstractions;
 using Ingweland.Fog.Application.Client.Web.CityPlanner.Stats;
 using Ingweland.Fog.Application.Client.Web.CityPlanner.Stats.BuildingTypedStats;
 using Ingweland.Fog.Application.Client.Web.CommandCenter;
@@ -19,9 +21,12 @@ using Ingweland.Fog.Application.Client.Web.Services.Hoh;
 using Ingweland.Fog.Application.Client.Web.Services.Hoh.Abstractions;
 using Ingweland.Fog.Application.Core.Calculators;
 using Ingweland.Fog.Application.Core.Calculators.Interfaces;
+using Ingweland.Fog.Application.Core.Factories;
+using Ingweland.Fog.Application.Core.Factories.Interfaces;
 using Ingweland.Fog.Application.Core.Formatters;
 using Ingweland.Fog.Application.Core.Formatters.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Polly;
 
 namespace Ingweland.Fog.Application.Client.Web;
@@ -97,6 +102,8 @@ public static class DependencyInjection
         services.AddScoped<IHohCommandCenterProfileFactory, CcProfileFactory>();
         services.AddScoped<ICcProfileUiService, CcProfileUiService>();
         services.AddScoped<ICcHeroesPlaygroundUiService, CcHeroesPlaygroundUiService>();
+        services.AddScoped<ISnapshotsComparisonViewModelFactory, SnapshotsComparisonViewModelFactory>();
+        services.TryAddScoped<IHohCitySnapshotFactory, HohCitySnapshotFactory>();
         services.AddScoped<CityPlannerSettings>();
 
         services.AddHttpClient<IWikipediaService, WikipediaService>()

--- a/src/Application.Client.Web/Localization/FogResource.Designer.cs
+++ b/src/Application.Client.Web/Localization/FogResource.Designer.cs
@@ -321,6 +321,42 @@ namespace Ingweland.Fog.Application.Client.Web.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Compare.
+        /// </summary>
+        public static string CityPlanner_Snapshots_Compare {
+            get {
+                return ResourceManager.GetString("CityPlanner.Snapshots.Compare", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Current.
+        /// </summary>
+        public static string CityPlanner_Snapshots_Current {
+            get {
+                return ResourceManager.GetString("CityPlanner.Snapshots.Current", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do you want to load {0} snapshot? This will reset your current city. This action cannot be undone..
+        /// </summary>
+        public static string CityPlanner_Snapshots_LoadConfirmation {
+            get {
+                return ResourceManager.GetString("CityPlanner.Snapshots.LoadConfirmation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Snapshots.
+        /// </summary>
+        public static string CityPlanner_Snapshots_Title {
+            get {
+                return ResourceManager.GetString("CityPlanner.Snapshots.Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to City planner.
         /// </summary>
         public static string CityPlanner_Title {
@@ -380,15 +416,6 @@ namespace Ingweland.Fog.Application.Client.Web.Localization {
         public static string CommandCenter_CreateProfile {
             get {
                 return ResourceManager.GetString("CommandCenter.CreateProfile", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Do you want to delete {0}?.
-        /// </summary>
-        public static string CommandCenter_DeleteCcProfileDialog_Message {
-            get {
-                return ResourceManager.GetString("CommandCenter.DeleteCcProfileDialog.Message", resourceCulture);
             }
         }
         
@@ -645,6 +672,15 @@ namespace Ingweland.Fog.Application.Client.Web.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Do you want to delete {0}?.
+        /// </summary>
+        public static string Common_DeleteConfirmation {
+            get {
+                return ResourceManager.GetString("Common.DeleteConfirmation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Disclaimer.
         /// </summary>
         public static string Common_Disclaimer {
@@ -704,6 +740,15 @@ namespace Ingweland.Fog.Application.Client.Web.Localization {
         public static string Common_JoinDiscord {
             get {
                 return ResourceManager.GetString("Common.JoinDiscord", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Load.
+        /// </summary>
+        public static string Common_Load {
+            get {
+                return ResourceManager.GetString("Common.Load", resourceCulture);
             }
         }
         

--- a/src/Application.Client.Web/Localization/FogResource.cs.resx
+++ b/src/Application.Client.Web/Localization/FogResource.cs.resx
@@ -427,4 +427,19 @@ Forge of Games není přidružený ani oficiálně spojený s tvůrci nebo vydav
     <data name="SupportUs.Why.Reason4" xml:space="preserve">
     <value>Stát se součástí naší rostoucí herní komunity</value>
 </data>
+    <data name="CityPlanner.Snapshots.Title" xml:space="preserve">
+    <value>Snímky</value>
+</data>
+    <data name="CityPlanner.Snapshots.Compare" xml:space="preserve">
+    <value>Porovnat</value>
+</data>
+    <data name="CityPlanner.Snapshots.LoadConfirmation" xml:space="preserve">
+    <value>Chcete načíst snímek {0}? Tím se resetuje vaše současné město. Tuto akci nelze vrátit zpět.</value>
+</data>
+    <data name="CityPlanner.Snapshots.Current" xml:space="preserve">
+    <value>Aktuální</value>
+</data>
+    <data name="Common.Load" xml:space="preserve">
+    <value>Načíst</value>
+</data>
 </root>

--- a/src/Application.Client.Web/Localization/FogResource.cs.resx
+++ b/src/Application.Client.Web/Localization/FogResource.cs.resx
@@ -376,7 +376,7 @@ Forge of Games není přidružený ani oficiálně spojený s tvůrci nebo vydav
     <data name="Common.Settings" xml:space="preserve">
     <value>Nastavení</value>
 </data>
-    <data name="CommandCenter.DeleteCcProfileDialog.Message" xml:space="preserve">
+    <data name="Common.DeleteConfirmation" xml:space="preserve">
     <value>Chcete smazat {0}?</value>
 </data>
     <data name="CommandCenter.Profile.Settings.ProfileName" xml:space="preserve">

--- a/src/Application.Client.Web/Localization/FogResource.de.resx
+++ b/src/Application.Client.Web/Localization/FogResource.de.resx
@@ -427,4 +427,19 @@ Forge of Games ist weder mit den Erstellern noch mit den Herausgebern von Heroes
     <data name="SupportUs.Why.Reason4" xml:space="preserve">
     <value>Werde Teil unserer wachsenden Gaming-Community</value>
 </data>
+    <data name="CityPlanner.Snapshots.Title" xml:space="preserve">
+    <value>Schnappschüsse</value>
+</data>
+    <data name="CityPlanner.Snapshots.Compare" xml:space="preserve">
+    <value>Vergleichen</value>
+</data>
+    <data name="CityPlanner.Snapshots.LoadConfirmation" xml:space="preserve">
+    <value>Möchtest du den Schnappschuss {0} laden? Dies wird deine aktuelle Stadt zurücksetzen. Diese Aktion kann nicht rückgängig gemacht werden.</value>
+</data>
+    <data name="CityPlanner.Snapshots.Current" xml:space="preserve">
+    <value>Aktuell</value>
+</data>
+    <data name="Common.Load" xml:space="preserve">
+    <value>Laden</value>
+</data>
 </root>

--- a/src/Application.Client.Web/Localization/FogResource.de.resx
+++ b/src/Application.Client.Web/Localization/FogResource.de.resx
@@ -376,7 +376,7 @@ Forge of Games ist weder mit den Erstellern noch mit den Herausgebern von Heroes
     <data name="Common.Settings" xml:space="preserve">
     <value>Einstellungen</value>
 </data>
-    <data name="CommandCenter.DeleteCcProfileDialog.Message" xml:space="preserve">
+    <data name="Common.DeleteConfirmation" xml:space="preserve">
     <value>Möchtest du {0} löschen?</value>
 </data>
     <data name="CommandCenter.Profile.Settings.ProfileName" xml:space="preserve">

--- a/src/Application.Client.Web/Localization/FogResource.es.resx
+++ b/src/Application.Client.Web/Localization/FogResource.es.resx
@@ -376,7 +376,7 @@ Forge of Games no está afiliado ni tiene conexión oficial con los creadores o 
     <data name="Common.Settings" xml:space="preserve">
     <value>Ajustes</value>
 </data>
-    <data name="CommandCenter.DeleteCcProfileDialog.Message" xml:space="preserve">
+    <data name="Common.DeleteConfirmation" xml:space="preserve">
     <value>¿Quieres eliminar {0}?</value>
 </data>
     <data name="CommandCenter.Profile.Settings.ProfileName" xml:space="preserve">

--- a/src/Application.Client.Web/Localization/FogResource.es.resx
+++ b/src/Application.Client.Web/Localization/FogResource.es.resx
@@ -427,4 +427,19 @@ Forge of Games no está afiliado ni tiene conexión oficial con los creadores o 
     <data name="SupportUs.Why.Reason4" xml:space="preserve">
     <value>Ser parte de nuestra creciente comunidad de jugadores</value>
 </data>
+    <data name="CityPlanner.Snapshots.Title" xml:space="preserve">
+    <value>Instantáneas</value>
+</data>
+    <data name="CityPlanner.Snapshots.Compare" xml:space="preserve">
+    <value>Comparar</value>
+</data>
+    <data name="CityPlanner.Snapshots.LoadConfirmation" xml:space="preserve">
+    <value>¿Quieres cargar la instantánea {0}? Esto reiniciará tu ciudad actual. Esta acción no se puede deshacer.</value>
+</data>
+    <data name="CityPlanner.Snapshots.Current" xml:space="preserve">
+    <value>Actual</value>
+</data>
+    <data name="Common.Load" xml:space="preserve">
+    <value>Cargar</value>
+</data>
 </root>

--- a/src/Application.Client.Web/Localization/FogResource.fr.resx
+++ b/src/Application.Client.Web/Localization/FogResource.fr.resx
@@ -376,7 +376,7 @@ Forge of Games n’est pas affilié ou officiellement associé aux créateurs ou
     <data name="Common.Settings" xml:space="preserve">
     <value>Paramètres</value>
 </data>
-    <data name="CommandCenter.DeleteCcProfileDialog.Message" xml:space="preserve">
+    <data name="Common.DeleteConfirmation" xml:space="preserve">
     <value>Voulez-vous supprimer {0} ?</value>
 </data>
     <data name="CommandCenter.Profile.Settings.ProfileName" xml:space="preserve">

--- a/src/Application.Client.Web/Localization/FogResource.fr.resx
+++ b/src/Application.Client.Web/Localization/FogResource.fr.resx
@@ -427,4 +427,19 @@ Forge of Games n’est pas affilié ou officiellement associé aux créateurs ou
     <data name="SupportUs.Why.Reason4" xml:space="preserve">
     <value>Faire partie de notre communauté grandissante de joueurs</value>
 </data>
+    <data name="CityPlanner.Snapshots.Title" xml:space="preserve">
+    <value>Instantanés</value>
+</data>
+    <data name="CityPlanner.Snapshots.Compare" xml:space="preserve">
+    <value>Comparer</value>
+</data>
+    <data name="CityPlanner.Snapshots.LoadConfirmation" xml:space="preserve">
+    <value>Voulez-vous charger l'instantané {0} ? Cela réinitialisera votre cité actuelle. Cette action ne peut pas être annulée.</value>
+</data>
+    <data name="CityPlanner.Snapshots.Current" xml:space="preserve">
+    <value>Actuel</value>
+</data>
+    <data name="Common.Load" xml:space="preserve">
+    <value>Charger</value>
+</data>
 </root>

--- a/src/Application.Client.Web/Localization/FogResource.it.resx
+++ b/src/Application.Client.Web/Localization/FogResource.it.resx
@@ -376,7 +376,7 @@ Forge of Games non è affiliato né ufficialmente connesso ai creatori o editori
     <data name="Common.Settings" xml:space="preserve">
     <value>Impostazioni</value>
 </data>
-    <data name="CommandCenter.DeleteCcProfileDialog.Message" xml:space="preserve">
+    <data name="Common.DeleteConfirmation" xml:space="preserve">
     <value>Vuoi eliminare {0}?</value>
 </data>
     <data name="CommandCenter.Profile.Settings.ProfileName" xml:space="preserve">

--- a/src/Application.Client.Web/Localization/FogResource.it.resx
+++ b/src/Application.Client.Web/Localization/FogResource.it.resx
@@ -427,4 +427,19 @@ Forge of Games non è affiliato né ufficialmente connesso ai creatori o editori
     <data name="SupportUs.Why.Reason4" xml:space="preserve">
     <value>Far parte della nostra crescente comunità di gioco</value>
 </data>
+    <data name="CityPlanner.Snapshots.Title" xml:space="preserve">
+    <value>Istantanee</value>
+</data>
+    <data name="CityPlanner.Snapshots.Compare" xml:space="preserve">
+    <value>Confronta</value>
+</data>
+    <data name="CityPlanner.Snapshots.LoadConfirmation" xml:space="preserve">
+    <value>Vuoi caricare l'istantanea {0}? Questo resetterà la tua città attuale. Questa azione non può essere annullata.</value>
+</data>
+    <data name="CityPlanner.Snapshots.Current" xml:space="preserve">
+    <value>Attuale</value>
+</data>
+    <data name="Common.Load" xml:space="preserve">
+    <value>Carica</value>
+</data>
 </root>

--- a/src/Application.Client.Web/Localization/FogResource.ja.resx
+++ b/src/Application.Client.Web/Localization/FogResource.ja.resx
@@ -376,7 +376,7 @@ Forge of Gamesは、Heroes of Historyの開発者または発行者と提携し�
     <data name="Common.Settings" xml:space="preserve">
     <value>設定</value>
 </data>
-    <data name="CommandCenter.DeleteCcProfileDialog.Message" xml:space="preserve">
+    <data name="Common.DeleteConfirmation" xml:space="preserve">
     <value>{0}を削除しますか？</value>
 </data>
     <data name="CommandCenter.Profile.Settings.ProfileName" xml:space="preserve">

--- a/src/Application.Client.Web/Localization/FogResource.ja.resx
+++ b/src/Application.Client.Web/Localization/FogResource.ja.resx
@@ -427,4 +427,19 @@ Forge of Gamesは、Heroes of Historyの開発者または発行者と提携し�
     <data name="SupportUs.Why.Reason4" xml:space="preserve">
     <value>成長するゲームコミュニティの一員になる</value>
 </data>
+    <data name="CityPlanner.Snapshots.Title" xml:space="preserve">
+    <value>スナップショット</value>
+</data>
+    <data name="CityPlanner.Snapshots.Compare" xml:space="preserve">
+    <value>比較</value>
+</data>
+    <data name="CityPlanner.Snapshots.LoadConfirmation" xml:space="preserve">
+    <value>スナップショット{0}を読み込みますか？現在の都市がリセットされます。この操作は取り消せません。</value>
+</data>
+    <data name="CityPlanner.Snapshots.Current" xml:space="preserve">
+    <value>現在</value>
+</data>
+    <data name="Common.Load" xml:space="preserve">
+    <value>読み込む</value>
+</data>
 </root>

--- a/src/Application.Client.Web/Localization/FogResource.nl.resx
+++ b/src/Application.Client.Web/Localization/FogResource.nl.resx
@@ -376,7 +376,7 @@ Forge of Games is niet verbonden met of officieel gelieerd aan de makers of uitg
     <data name="Common.Settings" xml:space="preserve">
     <value>Instellingen</value>
 </data>
-    <data name="CommandCenter.DeleteCcProfileDialog.Message" xml:space="preserve">
+    <data name="Common.DeleteConfirmation" xml:space="preserve">
     <value>Wil je {0} verwijderen?</value>
 </data>
     <data name="CommandCenter.Profile.Settings.ProfileName" xml:space="preserve">

--- a/src/Application.Client.Web/Localization/FogResource.nl.resx
+++ b/src/Application.Client.Web/Localization/FogResource.nl.resx
@@ -427,4 +427,19 @@ Forge of Games is niet verbonden met of officieel gelieerd aan de makers of uitg
     <data name="SupportUs.Why.Reason4" xml:space="preserve">
     <value>Word deel van onze groeiende gamegemeenschap</value>
 </data>
+    <data name="CityPlanner.Snapshots.Title" xml:space="preserve">
+    <value>Momentopnames</value>
+</data>
+    <data name="CityPlanner.Snapshots.Compare" xml:space="preserve">
+    <value>Vergelijken</value>
+</data>
+    <data name="CityPlanner.Snapshots.LoadConfirmation" xml:space="preserve">
+    <value>Wil je momentopname {0} laden? Dit zal je huidige stad resetten. Deze actie kan niet ongedaan worden gemaakt.</value>
+</data>
+    <data name="CityPlanner.Snapshots.Current" xml:space="preserve">
+    <value>Huidig</value>
+</data>
+    <data name="Common.Load" xml:space="preserve">
+    <value>Laden</value>
+</data>
 </root>

--- a/src/Application.Client.Web/Localization/FogResource.pl.resx
+++ b/src/Application.Client.Web/Localization/FogResource.pl.resx
@@ -427,4 +427,19 @@ Forge of Games nie jest powiązany ani oficjalnie związany z twórcami lub wyda
     <data name="SupportUs.Why.Reason4" xml:space="preserve">
     <value>Stań się częścią naszej rosnącej społeczności graczy</value>
 </data>
+    <data name="CityPlanner.Snapshots.Title" xml:space="preserve">
+    <value>Migawki</value>
+</data>
+    <data name="CityPlanner.Snapshots.Compare" xml:space="preserve">
+    <value>Porównaj</value>
+</data>
+    <data name="CityPlanner.Snapshots.LoadConfirmation" xml:space="preserve">
+    <value>Czy chcesz wczytać migawkę {0}? Spowoduje to reset obecnego miasta. Tej akcji nie można cofnąć.</value>
+</data>
+    <data name="CityPlanner.Snapshots.Current" xml:space="preserve">
+    <value>Obecne</value>
+</data>
+    <data name="Common.Load" xml:space="preserve">
+    <value>Wczytaj</value>
+</data>
 </root>

--- a/src/Application.Client.Web/Localization/FogResource.pl.resx
+++ b/src/Application.Client.Web/Localization/FogResource.pl.resx
@@ -376,7 +376,7 @@ Forge of Games nie jest powiązany ani oficjalnie związany z twórcami lub wyda
     <data name="Common.Settings" xml:space="preserve">
     <value>Ustawienia</value>
 </data>
-    <data name="CommandCenter.DeleteCcProfileDialog.Message" xml:space="preserve">
+    <data name="Common.DeleteConfirmation" xml:space="preserve">
     <value>Czy chcesz usunąć {0}?</value>
 </data>
     <data name="CommandCenter.Profile.Settings.ProfileName" xml:space="preserve">

--- a/src/Application.Client.Web/Localization/FogResource.resx
+++ b/src/Application.Client.Web/Localization/FogResource.resx
@@ -381,7 +381,7 @@
     <data name="Common.Settings" xml:space="preserve">
         <value>Settings</value>
     </data>
-    <data name="CommandCenter.DeleteCcProfileDialog.Message" xml:space="preserve">
+    <data name="Common.DeleteConfirmation" xml:space="preserve">
         <value>Do you want to delete {0}?</value>
     </data>
     <data name="CommandCenter.Profile.Settings.ProfileName" xml:space="preserve">
@@ -431,5 +431,20 @@
     </data>
     <data name="SupportUs.Why.Reason4" xml:space="preserve">
         <value>Be part of our growing gaming community</value>
+    </data>
+    <data name="CityPlanner.Snapshots.Title" xml:space="preserve">
+        <value>Snapshots</value>
+    </data>
+    <data name="CityPlanner.Snapshots.Compare" xml:space="preserve">
+        <value>Compare</value>
+    </data>
+    <data name="CityPlanner.Snapshots.LoadConfirmation" xml:space="preserve">
+        <value>Do you want to load {0} snapshot? This will reset your current city. This action cannot be undone.</value>
+    </data>
+    <data name="CityPlanner.Snapshots.Current" xml:space="preserve">
+        <value>Current</value>
+    </data>
+    <data name="Common.Load" xml:space="preserve">
+        <value>Load</value>
     </data>
 </root>

--- a/src/Application.Client.Web/Localization/FogResource.zh.resx
+++ b/src/Application.Client.Web/Localization/FogResource.zh.resx
@@ -376,7 +376,7 @@ Forge of Games 與 Heroes of History 的創作者或出版商無關，也沒有�
     <data name="Common.Settings" xml:space="preserve">
     <value>設定</value>
 </data>
-    <data name="CommandCenter.DeleteCcProfileDialog.Message" xml:space="preserve">
+    <data name="Common.DeleteConfirmation" xml:space="preserve">
     <value>是否要刪除 {0}？</value>
 </data>
     <data name="CommandCenter.Profile.Settings.ProfileName" xml:space="preserve">

--- a/src/Application.Client.Web/Localization/FogResource.zh.resx
+++ b/src/Application.Client.Web/Localization/FogResource.zh.resx
@@ -427,4 +427,19 @@ Forge of Games 與 Heroes of History 的創作者或出版商無關，也沒有�
     <data name="SupportUs.Why.Reason4" xml:space="preserve">
     <value>成為我們不斷成長的遊戲社群的一份子</value>
 </data>
+    <data name="CityPlanner.Snapshots.Title" xml:space="preserve">
+    <value>快照</value>
+</data>
+    <data name="CityPlanner.Snapshots.Compare" xml:space="preserve">
+    <value>比較</value>
+</data>
+    <data name="CityPlanner.Snapshots.LoadConfirmation" xml:space="preserve">
+    <value>您要載入快照 {0} 嗎？這將重置您目前的城市。此操作無法撤消。</value>
+</data>
+    <data name="CityPlanner.Snapshots.Current" xml:space="preserve">
+    <value>目前</value>
+</data>
+    <data name="Common.Load" xml:space="preserve">
+    <value>載入</value>
+</data>
 </root>

--- a/src/Application.Core/Constants/FogConstants.cs
+++ b/src/Application.Core/Constants/FogConstants.cs
@@ -3,4 +3,5 @@ namespace Ingweland.Fog.Application.Core.Constants;
 public static class FogConstants
 {
     public const int NAME_MAX_CHARACTERS = 40;
+    public static readonly int MaxHohCitySnapshots = 5;
 }

--- a/src/Application.Core/Factories/HohCitySnapshotFactory.cs
+++ b/src/Application.Core/Factories/HohCitySnapshotFactory.cs
@@ -1,0 +1,23 @@
+using Ingweland.Fog.Application.Core.Factories.Interfaces;
+using Ingweland.Fog.Models.Fog.Entities;
+
+namespace Ingweland.Fog.Application.Core.Factories;
+
+public class HohCitySnapshotFactory() : IHohCitySnapshotFactory
+{
+    public HohCitySnapshot Create(IEnumerable<HohCityMapEntity> cityMapEntities)
+    {
+        return Create(cityMapEntities, null);
+    }
+
+    public HohCitySnapshot Create(IEnumerable<HohCityMapEntity> cityMapEntities, string? name)
+    {
+        return new HohCitySnapshot()
+        {
+            Id = Guid.NewGuid().ToString(),
+            CreatedDateUtc = DateTime.UtcNow,
+            Name = name,
+            Entities = cityMapEntities.Select(src => src.Clone()).ToList(),
+        };
+    }
+}

--- a/src/Application.Core/Factories/Interfaces/IHohCitySnapshotFactory.cs
+++ b/src/Application.Core/Factories/Interfaces/IHohCitySnapshotFactory.cs
@@ -1,0 +1,9 @@
+using Ingweland.Fog.Models.Fog.Entities;
+
+namespace Ingweland.Fog.Application.Core.Factories.Interfaces;
+
+public interface IHohCitySnapshotFactory
+{
+    HohCitySnapshot Create(IEnumerable<HohCityMapEntity> cityMapEntities);
+    HohCitySnapshot Create(IEnumerable<HohCityMapEntity> cityMapEntities, string? name);
+}

--- a/src/Application.Server/DependencyInjection.cs
+++ b/src/Application.Server/DependencyInjection.cs
@@ -1,11 +1,14 @@
 using Ingweland.Fog.Application.Core.Calculators;
 using Ingweland.Fog.Application.Core.Calculators.Interfaces;
+using Ingweland.Fog.Application.Core.Factories;
+using Ingweland.Fog.Application.Core.Factories.Interfaces;
 using Ingweland.Fog.Application.Core.Services.Hoh.Abstractions;
 using Ingweland.Fog.Application.Server.Factories;
 using Ingweland.Fog.Application.Server.Factories.Interfaces;
 using Ingweland.Fog.Application.Server.Services.Hoh;
 using Ingweland.Fog.Application.Server.Services.Hoh.Abstractions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 
 namespace Ingweland.Fog.Application.Server;
@@ -41,5 +44,6 @@ public static class DependencyInjection
         services.AddScoped<ICommandCenterService, CommandCenterService>();
         services.AddScoped<IBarracksProfileFactory, BarracksProfileFactory>();
         services.AddScoped<ICommandCenterProfileFactory, CommandCenterProfileFactory>();
+        services.TryAddScoped<IHohCitySnapshotFactory, HohCitySnapshotFactory>();
     }
 }

--- a/src/Application.Server/Services/Hoh/InGameStartupDataProcessingService.cs
+++ b/src/Application.Server/Services/Hoh/InGameStartupDataProcessingService.cs
@@ -105,7 +105,7 @@ public class InGameStartupDataProcessingService(
         if (capital != null)
         {
             var buildings = await coreDataRepository.GetBuildingsAsync(CityId.Capital);
-            barracksProfile = barracksProfileFactory.Create(capital.Entities.AsReadOnly(), buildings);
+            barracksProfile = barracksProfileFactory.Create(capital.Entities, buildings);
         }
         else
         {

--- a/src/Models.Fog/Entities/HohCity.cs
+++ b/src/Models.Fog/Entities/HohCity.cs
@@ -1,13 +1,13 @@
-using Ingweland.Fog.Models.Hoh.Constants;
 using Ingweland.Fog.Models.Hoh.Enums;
 
 namespace Ingweland.Fog.Models.Fog.Entities;
 
 public class HohCity
 {
+    public required string AgeId { get; set; }
+    public IReadOnlyCollection<HohCityMapEntity> Entities { get; set; } = new List<HohCityMapEntity>();
     public required string Id { get; set; }
     public CityId InGameCityId { get; set; }
-    public IList<HohCityMapEntity> Entities { get; set; } = new List<HohCityMapEntity>();
-    public required string AgeId { get; set; }
     public required string Name { get; set; }
+    public IReadOnlyCollection<HohCitySnapshot> Snapshots { get; init; } = new List<HohCitySnapshot>();
 }

--- a/src/Models.Fog/Entities/HohCityMapEntity.cs
+++ b/src/Models.Fog/Entities/HohCityMapEntity.cs
@@ -1,13 +1,29 @@
+using System.Text.Json.Serialization;
+
 namespace Ingweland.Fog.Models.Fog.Entities;
 
 public class HohCityMapEntity
 {
     public required string CityEntityId { get; set; }
-    public int Id { get; set; }
-    public bool IsRotated { get; set; }
-    public required int Level { get; set; }
-    public string? SelectedProductId { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public string? CustomizationId { get; set; }
+
+    public int Id { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool IsRotated { get; set; }
+
+    public required int Level { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public string? SelectedProductId { get; set; }
+
     public int X { get; set; }
     public int Y { get; set; }
+
+    public HohCityMapEntity Clone()
+    {
+        return (HohCityMapEntity) MemberwiseClone();
+    }
 }

--- a/src/Models.Fog/Entities/HohCitySnapshot.cs
+++ b/src/Models.Fog/Entities/HohCitySnapshot.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+
+namespace Ingweland.Fog.Models.Fog.Entities;
+
+public class HohCitySnapshot
+{
+    public required DateTime CreatedDateUtc { get; init; }
+    public IReadOnlyCollection<HohCityMapEntity> Entities { get; init; } = new List<HohCityMapEntity>();
+    public required string Id { get; init; }
+    public string? Name { get; init; }
+
+    [JsonIgnore]
+    public string ComputedName => Name ?? CreatedDateUtc.ToLocalTime().ToString("G");
+}

--- a/src/WebApp.Client/Components/Elements/CityPlanner/CityPlannerComponent.razor
+++ b/src/WebApp.Client/Components/Elements/CityPlanner/CityPlannerComponent.razor
@@ -90,6 +90,13 @@
                     </div>
 
                 </MudTabPanel>
+                <MudTabPanel Class="fog-icon-light" Icon="@Icons.Material.Outlined.ViewList">
+                    <div class="city-planner-side-panel">
+                        <CityPlannerSnapshotsComponent OnCreate="CreateSnapshot" OnDelete="DeleteSnapshot"
+                                                       OnLoad="LoadSnapshot" OnCompare="CompareSnapshots"
+                                                       Snapshots="@CityPlanner!.CityMapState.Snapshots"/>
+                    </div>
+                </MudTabPanel>
                 <MudTabPanel Class="fog-icon-light" Icon="@Icons.Material.Outlined.Settings">
                     <div class="city-planner-side-panel">
                         <CityPlannerSettingsComponent/>

--- a/src/WebApp.Client/Components/Elements/CityPlanner/CityPlannerComponent.razor.cs
+++ b/src/WebApp.Client/Components/Elements/CityPlanner/CityPlannerComponent.razor.cs
@@ -146,14 +146,14 @@ public partial class CityPlannerComponent : ComponentBase, IDisposable
         _skCanvasView!.Invalidate();
     }
 
-    private static DialogOptions GetDefaultDialogOptions(bool closButton = false)
+    private static DialogOptions GetDefaultDialogOptions(bool closeButton = false)
     {
         return new DialogOptions
         {
             MaxWidth = MaxWidth.Small,
             FullWidth = true,
             BackgroundClass = "dialog-blur-bg",
-            CloseButton = closButton,
+            CloseButton = closeButton,
         };
     }
 
@@ -322,7 +322,7 @@ public partial class CityPlannerComponent : ComponentBase, IDisposable
 
     private async Task Save()
     {
-        await PersistenceService.SaveCity(CityPlanner!.GetCity());
+        await CityPlanner.SaveCity();
     }
 
     private void SelectGroup()
@@ -376,5 +376,35 @@ public partial class CityPlannerComponent : ComponentBase, IDisposable
         {
             _skCanvasView!.Invalidate();
         }
+    }
+    
+    private async Task LoadSnapshot(string id)
+    {
+        await CityPlanner.LoadSnapshot(id);
+    }
+    
+    private async Task CreateSnapshot()
+    {
+        await CityPlanner.CreateSnapshot();
+    }
+    private async Task CompareSnapshots()
+    {
+        var viewModel = CityPlanner.CompareSnapshots();
+        
+        var parameters = new DialogParameters<SnapshotsComparisonComponent>{{src => src.Data, viewModel}};
+
+        var options = new DialogOptions
+        {
+            FullWidth = true,
+            BackgroundClass = "dialog-blur-bg",
+            NoHeader = true,
+            CloseOnEscapeKey = true,
+        };
+        await DialogService.ShowAsync<SnapshotsComparisonComponent>(null, parameters, options);
+    }
+    
+    private async Task DeleteSnapshot(string id)
+    {
+        await CityPlanner.DeleteSnapshot(id);
     }
 }

--- a/src/WebApp.Client/Components/Elements/CityPlanner/CityPlannerSnapshotsComponent.razor
+++ b/src/WebApp.Client/Components/Elements/CityPlanner/CityPlannerSnapshotsComponent.razor
@@ -6,9 +6,13 @@
 @inject CityPlannerSettings CityPlannerSettings
 @inject IStringLocalizer<FogResource> Loc
 @inject IDialogService DialogService
+@inject IJSRuntime JSRuntime
 
 <div class="fog-container component-root">
-    <div class="section-title">@Loc[FogResource.CityPlanner_Snapshots_Title]</div>
+    <div class="header-container">
+        <div class="section-title">@Loc[FogResource.CityPlanner_Snapshots_Title]</div>
+        <MudIconButton Icon="@Icons.Material.Outlined.Help" Color="Color.Inherit" OnClick="@(() => OpenHelp())"/>
+    </div>
     <div class="main-container">
         <div class="items-container">
             @foreach (var ss in Snapshots)
@@ -31,6 +35,7 @@
 </div>
 
 @code {
+    private const string HELP_URL = "help/city-planner-snapshots";
 
     [Parameter]
     public required IReadOnlyCollection<HohCitySnapshot> Snapshots { get; set; }
@@ -69,6 +74,11 @@
         {
             await OnLoad.InvokeAsync(snapshot.Id);
         }
+    }
+
+    private async Task OpenHelp()
+    {
+        await JSRuntime.InvokeVoidAsync("open", HELP_URL, "_blank");
     }
 
 }

--- a/src/WebApp.Client/Components/Elements/CityPlanner/CityPlannerSnapshotsComponent.razor
+++ b/src/WebApp.Client/Components/Elements/CityPlanner/CityPlannerSnapshotsComponent.razor
@@ -1,0 +1,74 @@
+@using Ingweland.Fog.Application.Client.Web.CityPlanner
+@using Ingweland.Fog.Application.Client.Web.Localization
+@using Ingweland.Fog.Application.Core.Constants
+@using Ingweland.Fog.Models.Fog.Entities
+@using Microsoft.Extensions.Localization
+@inject CityPlannerSettings CityPlannerSettings
+@inject IStringLocalizer<FogResource> Loc
+@inject IDialogService DialogService
+
+<div class="fog-container component-root">
+    <div class="section-title">@Loc[FogResource.CityPlanner_Snapshots_Title]</div>
+    <div class="main-container">
+        <div class="items-container">
+            @foreach (var ss in Snapshots)
+            {
+                <div class="snapshot-item">
+                    <span class="snapshot-item-label">@ss.ComputedName</span>
+                    <MudIconButton Icon="@Icons.Material.Outlined.Publish" Size="Size.Small"
+                                   OnClick="() => OnLoadClicked(ss)"/>
+                    <MudIconButton Icon="@Icons.Material.Outlined.Delete" Size="Size.Small"
+                                   OnClick="() => OnDeleteClicked(ss)"/>
+                </div>
+            }
+        </div>
+
+        <MudButton Variant="Variant.Outlined" OnClick="OnCreate"
+                   Disabled="@(Snapshots.Count >= FogConstants.MaxHohCitySnapshots)">@Loc[FogResource.Common_Create]</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="OnCompare"
+                   Disabled="@(Snapshots.Count == 0)">@Loc[FogResource.CityPlanner_Snapshots_Compare]</MudButton>
+    </div>
+</div>
+
+@code {
+
+    [Parameter]
+    public required IReadOnlyCollection<HohCitySnapshot> Snapshots { get; set; }
+
+    [Parameter]
+    public EventCallback OnCreate { get; set; }
+
+    [Parameter]
+    public EventCallback OnCompare { get; set; }
+
+    [Parameter]
+    public EventCallback<string> OnDelete { get; set; }
+
+    [Parameter]
+    public EventCallback<string> OnLoad { get; set; }
+
+    private async Task OnDeleteClicked(HohCitySnapshot snapshot)
+    {
+        var result = await DialogService.ShowMessageBox(
+            null,
+            Loc[FogResource.Common_DeleteConfirmation, snapshot.CreatedDateUtc.ToLocalTime().ToString("G")],
+            yesText: Loc[FogResource.Common_Delete], cancelText: Loc[FogResource.Common_Cancel]);
+        if (result != null)
+        {
+            await OnDelete.InvokeAsync(snapshot.Id);
+        }
+    }
+
+    private async Task OnLoadClicked(HohCitySnapshot snapshot)
+    {
+        var result = await DialogService.ShowMessageBox(
+            null,
+            Loc[FogResource.CityPlanner_Snapshots_LoadConfirmation, snapshot.CreatedDateUtc.ToLocalTime().ToString("G")],
+            yesText: Loc[FogResource.Common_Load], cancelText: Loc[FogResource.Common_Cancel]);
+        if (result != null)
+        {
+            await OnLoad.InvokeAsync(snapshot.Id);
+        }
+    }
+
+}

--- a/src/WebApp.Client/Components/Elements/CityPlanner/CityPlannerSnapshotsComponent.razor.css
+++ b/src/WebApp.Client/Components/Elements/CityPlanner/CityPlannerSnapshotsComponent.razor.css
@@ -1,7 +1,9 @@
 .component-root {
-    display: flex !important;
+    display: flex;
     flex-direction: column;
     clip-path: inset(0 0 0 0 round var(--fog-border-radius));
+    gap: 12px;
+    padding-bottom: 12px;
 }
 
 .main-container {
@@ -9,6 +11,7 @@
     flex-direction: column;
     padding-left: 12px;
     padding-right: 12px;
+    gap: 12px;
 }
 
 .section-title {
@@ -23,4 +26,22 @@
     min-height: 22px;
     min-width: 80px;
     text-align: center;
+}
+
+.items-container{
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.snapshot-item-label {
+    font-size: 12px;
+}
+
+.snapshot-item {
+    display: grid;
+    grid-template-columns: 1fr 32px 32px;
+    grid-template-rows: auto;
+    gap: 8px;
+    align-items: center;
 }

--- a/src/WebApp.Client/Components/Elements/CityPlanner/CityPlannerSnapshotsComponent.razor.css
+++ b/src/WebApp.Client/Components/Elements/CityPlanner/CityPlannerSnapshotsComponent.razor.css
@@ -5,6 +5,11 @@
     gap: 12px;
     padding-bottom: 12px;
 }
+.header-container {
+    display: flex;
+    justify-content: space-between;
+}
+
 
 .main-container {
     display: flex !important;

--- a/src/WebApp.Client/Components/Elements/CityPlanner/SnapshotsComparisonComponent.razor
+++ b/src/WebApp.Client/Components/Elements/CityPlanner/SnapshotsComparisonComponent.razor
@@ -1,0 +1,45 @@
+@using Ingweland.Fog.Application.Client.Web.CityPlanner.Snapshots
+@using Ingweland.Fog.Application.Client.Web.Localization
+@using Ingweland.Fog.Application.Client.Web.Providers.Interfaces
+@using Microsoft.Extensions.Localization
+@inject IHohStorageIconUrlProvider StorageIconUrlProvider
+<MudDialog Style="max-width: max-content">
+    <DialogContent>
+        <table class="table">
+            <thead>
+            <th/>
+            @foreach (var snapshot in Data.SnapshotNames)
+            {
+                <th>@snapshot</th>
+            }
+            </thead>
+            <tbody>
+            <tr>
+                <td colspan="@(Data.SnapshotNames.Count + 1)">
+                    <img src="@StorageIconUrlProvider.GetIconUrl(string.Empty)" class="icon"/></td>
+            </tr>
+            @foreach (var row in Data.Production)
+            {
+                <tr class="user-select-none">
+
+                    <td ><img src="@row.Header" class="icon"/></td>
+                    @foreach (var cell in row.Cells)
+                    {
+                        <td class="row-label" style="background-color: @(cell.IsLargest?"#CFFCEF":"transparent")">@cell.Value</td>
+                    }
+
+                </tr>
+            }
+            </tbody>
+        </table>
+    </DialogContent>
+</MudDialog>
+
+@code {
+
+    [CascadingParameter]
+    MudDialogInstance MudDialog { get; set; }
+
+    [Parameter]
+    public SnapshotsComparisonViewModel Data { get; set; }
+}

--- a/src/WebApp.Client/Components/Elements/CityPlanner/SnapshotsComparisonComponent.razor.css
+++ b/src/WebApp.Client/Components/Elements/CityPlanner/SnapshotsComparisonComponent.razor.css
@@ -1,0 +1,55 @@
+.icon {
+    width: 18px;
+    height: 18px;
+    object-fit: contain;
+}
+
+.row-label {
+    font-size: 12px !important;
+    vertical-align: middle;
+}
+
+.table {
+    margin-bottom: 0 !important;
+    width: 100%;
+}
+
+.table>:not(caption)>*>*:has(>img) {
+    padding: 2px 6px !important;
+    background-color: transparent;
+}
+
+.table>:not(caption)>*>* {
+    padding: 2px 6px !important;
+    background-color: transparent;
+}
+
+thead {
+    border-bottom: none;
+}
+
+th, td {
+    color: var(--fog-text-color) !important;
+    border-bottom: 0;
+    text-align: center;
+}
+th {
+    white-space: nowrap;
+    font-size: 12px !important;
+    font-weight: 700 !important;
+    background-color: var(--fog-surface2-color) !important;
+    padding: 4px 8px;
+}
+
+td > * {
+    vertical-align: middle;
+}
+input, tbody tr {
+    cursor: pointer;
+}
+
+tbody tr:nth-child(even) {
+    background-color: #f9fafb;
+}
+
+

--- a/src/WebApp.Client/Components/Pages/CommandCenter/CcProfileSettingsPage.razor.cs
+++ b/src/WebApp.Client/Components/Pages/CommandCenter/CcProfileSettingsPage.razor.cs
@@ -44,7 +44,7 @@ public partial class CcProfileSettingsPage : CcProfilePageBase
     {
         var result = await DialogService.ShowMessageBox(
             null,
-            Loc[FogResource.CommandCenter_DeleteCcProfileDialog_Message, Profile!.Name],
+            Loc[FogResource.Common_DeleteConfirmation, Profile!.Name],
             yesText: Loc[FogResource.Common_Delete], cancelText: Loc[FogResource.Common_Cancel]);
         if (result != null)
         {

--- a/src/WebApp/Components/Pages/HelpCityPlannerSnapshots.razor
+++ b/src/WebApp/Components/Pages/HelpCityPlannerSnapshots.razor
@@ -1,0 +1,68 @@
+@page "/help/city-planner-snapshots"
+<HeadContent>
+    <meta name="description"
+          content="Learn how to use Snapshots to save, compare, and manage different versions of your city layouts. Create snapshots and analyze how different designs affect your city's production.">
+    <meta name="keywords" content="city planner, Heroes of History, Hoh city planner, city snapshots, city layouts, city management, city comparison, city planning, city optimization, layout management, production analysis, city builder, city design">
+</HeadContent>
+<PageTitle>City Snapshots | Heroes of History | Forge of Games</PageTitle>
+<div class="container">
+    <h3>Snapshots: Save and Compare Your City Layouts</h3>
+
+    <div class="info">
+        <p>Snapshots let you save different versions of your city and switch between them. You can save up to 5 different snapshots and compare how your city performs across these different layouts.</p>
+    </div>
+
+    <div class="step">
+        <h5>What is a Snapshot?</h5>
+        <p>A snapshot saves your entire city layout at a specific moment. It preserves all buildings exactly as they are when you create it.</p>
+    </div>
+
+    <div class="step">
+        <h5>Creating Snapshots</h5>
+        <ol>
+            <li>Open the Snapshots menu in the right panel</li>
+            <li>Click the Create button to save your current city layout as a snapshot</li>
+            <li>The snapshot will be named with your current local time</li>
+            <li>Your city is automatically saved when creating a snapshot</li>
+        </ol>
+        <p class="note">Note: When you import a city, the system automatically creates an initial snapshot to help you track changes.</p>
+    </div>
+
+    <div class="step">
+        <h5>Managing Snapshots</h5>
+
+        <h6>Loading a Snapshot</h6>
+        <p>When you load a snapshot, your entire city layout will change to match that saved version. Important:</p>
+        <ul>
+            <li>Your current layout will be replaced</li>
+            <li>Changes are saved automatically</li>
+            <li>This action cannot be undone</li>
+        </ul>
+
+        <h6>Deleting a Snapshot</h6>
+        <p>You can remove any snapshot using the delete option in the Snapshots menu.</p>
+    </div>
+
+    <div class="step">
+        <h5>Comparing Layouts</h5>
+        <p>The comparison feature helps you see how different layouts affect your city's production.</p>
+
+        <p>How it works:</p>
+        <ul>
+            <li>Compare up to 6 different versions (5 snapshots plus your current layout)</li>
+            <li>Your current city layout is always included in the comparison</li>
+            <li>You need at least one snapshot to make comparisons</li>
+            <li>The comparison table shows production values for each resource</li>
+            <li>When production values in a row differ, the highest values are highlighted in green</li>
+        </ul>
+    </div>
+
+    <div class="step">
+        <h5>Additional Information</h5>
+        <ul>
+            <li>New cities start without any snapshots</li>
+            <li>Imported cities receive one automatic snapshot</li>
+            <li>Loading a snapshot permanently replaces your current layout</li>
+        </ul>
+    </div>
+</div>

--- a/src/WebApp/Components/Pages/HelpCityPlannerSnapshots.razor.css
+++ b/src/WebApp/Components/Pages/HelpCityPlannerSnapshots.razor.css
@@ -1,0 +1,36 @@
+.container {
+    line-height: 1.6;
+    background-color: var(--fog-surface-color);
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    padding: 2rem;
+}
+.step {
+    margin-bottom: 2rem;
+    padding: 1.5rem;
+    background-color: #f8f9fa;
+    border-radius: 6px;
+}
+.step h3 {
+    color: #2c5282;
+    margin-top: 0;
+}
+.info {
+    margin-top: 1.5rem;
+    margin-bottom: 2rem;
+    padding: 1.5rem;
+    background-color: #ebf8ff;
+    border-radius: 6px;
+    border-left: 4px solid #4299e1;
+}
+.privacy {
+    margin-top: 3rem;
+    padding: 1.5rem;
+    background-color: #f0fff4;
+    border-radius: 6px;
+    border-left: 4px solid #48bb78;
+}
+.privacy h2 {
+    color: #2f855a;
+    margin-top: 0;
+}


### PR DESCRIPTION
New City Planner snapshots functionality. It allows comparing version of the city. Currently supports comparing of production.